### PR TITLE
keepaliveOnce() refreshes lastKeepAlive

### DIFF
--- a/src/lease.ts
+++ b/src/lease.ts
@@ -194,6 +194,7 @@ export class Lease extends EventEmitter {
           throw err;
         }
 
+        this.lastKeepAlive = Date.now();
         return res;
       });
     });


### PR DESCRIPTION
`keepaliveOnce()` refreshes `lastKeepAlive` when the lease is not expired or revoked.