### PR TITLE
Fix usage example of defaultCallOptions

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -84,7 +84,7 @@ export interface IOptions {
    *
    * ```js
    * const etcd3 = new Etcd3({
-   *   defaultCallOptions: context => context.isStream ? {} : Date.now() + 10000,
+   *   defaultCallOptions: context => context.isStream ? {} : { deadline: Date.now() + 10000 },
    * });
    * ```
    *


### PR DESCRIPTION
The usage example of defaultCallOptions is wrong. 
The return value should be an object with `deadline` property