### PR TITLE
fix: a race condition in Host.resetAllServices

### DIFF
--- a/src/connection-pool.ts
+++ b/src/connection-pool.ts
@@ -210,7 +210,7 @@ export class Host {
         // workaround: https://github.com/grpc/grpc-node/issues/1487
         const state = service.getChannel().getConnectivityState(false);
         if (state === grpc.connectivityState.CONNECTING) {
-          service.waitForReady(Date.now() + 10_00, () => service.close());
+          service.waitForReady(Date.now() + 10_00, () => setImmediate(() => service.close()));
         } else {
           service.close();
         }


### PR DESCRIPTION
Fix a race condition in Host.resetAllServices() caused by calling channel.close() as a callback of grpc.Client.waitForReady().

The root cause is gRPC subchannel pool state could become into invalid state when global subchannel pool state is used, and there are multiple channels used the same subchannel from the pool.

Closing the channel inside of waitForReady callback prevent all the remaining callbacks for the subchannel from the correct state transition handling.

Closing the channel inside of waitForReady callback prevents the subchannel's remaining callbacks from the correct state transition handling.

The fix is to use setImmediate to allow the remaining callbacks for the subchannel to process the state transition.

The issue appears with grpc-js v1.6.7.