### PR TITLE
fix: resolve empty auth config

### DIFF
--- a/src/connection-pool.ts
+++ b/src/connection-pool.ts
@@ -98,7 +98,8 @@ class Authenticator {
       typeof this.options.hosts === 'string' ? [this.options.hosts] : this.options.hosts;
     const auth = this.options.auth;
 
-    if (!auth) {
+    const ignoreAuth = !auth || !(auth.username && auth.password);
+    if (ignoreAuth) {
       return Promise.resolve(new grpc.Metadata());
     }
 


### PR DESCRIPTION
fix empty auth config. take the following as example,
```javascript
import { Etcd3 } from 'etcd3'
const client = new Etcd3({
    hosts: '127.0.0.1:2379',
    auth: {
        username: '',
        password: ''
    }
});

(async () => {
    await client.put('foo').value('bar');
    const fooValue = await client.get('foo').string();
    console.log('foo was:', fooValue);
})()
```

exec code above will report grpc error
![image](https://github.com/microsoft/etcd3/assets/6478745/78331ef0-d545-4603-9383-eab8b4eaa221)


In face, if developer pass empty username or empty password should be treated as no auth

